### PR TITLE
redirect legacy addresses

### DIFF
--- a/src/server/accounts.rs
+++ b/src/server/accounts.rs
@@ -203,7 +203,7 @@ pub async fn get_account(
             Err(_) => {
                 Err((
                     StatusCode::BAD_REQUEST,
-                    format!("\"{account}\" is not a valid base58 encoded Solana pubkey."),
+                    format!("\"{account}\" is not a valid base58 encoded Solana (or Helium) pubkey."),
                 ))
             }
         }

--- a/src/server/epoch_info.rs
+++ b/src/server/epoch_info.rs
@@ -83,5 +83,5 @@ pub async fn get(
         EpochSummary::from_partial_data(last_epoch, mobile_vehnt, iot_vehnt, ts).unwrap();
     data.push(current_stats);
 
-    Ok(response::Json(json!(data)))
+    Ok(response::Json(json!(data)).into())
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,12 +13,38 @@ use serde_json::{json, Value};
 use tokio::time;
 
 pub type Result<T = ()> = std::result::Result<T, Error>;
-pub type HandlerResult = std::result::Result<response::Json<Value>, (StatusCode, String)>;
+pub type HandlerResult = std::result::Result<MyResponse, (StatusCode, String)>;
+
+pub enum MyResponse {
+    Json(response::Json<Value>),
+    Redirect(response::Redirect),
+}
+
+impl response::IntoResponse for MyResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Json(j) => j.into_response(),
+            Self::Redirect(r) => r.into_response(),
+        }
+    }
+}
+
+impl From<response::Json<Value>> for MyResponse {
+    fn from(j: response::Json<Value>) -> Self {
+        Self::Json(j)
+    }
+}
+impl From<response::Redirect> for MyResponse {
+    fn from(r: response::Redirect) -> Self {
+        Self::Redirect(r)
+    }
+}
 
 mod accounts;
 mod epoch_info;
 mod positions;
 
+use axum::response::Response;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 

--- a/src/server/positions/legacy.rs
+++ b/src/server/positions/legacy.rs
@@ -63,5 +63,5 @@ pub async fn delegated_stakes(
         timestamp: data.timestamp,
     };
 
-    Ok(response::Json(json!(data)))
+    Ok(response::Json(json!(data)).into())
 }

--- a/src/server/positions/metadata.rs
+++ b/src/server/positions/metadata.rs
@@ -33,5 +33,5 @@ pub async fn vehnt_positions_metadata(
         }
     }?;
 
-    Ok(response::Json(json!(data.stats)))
+    Ok(response::Json(json!(data.stats)).into())
 }

--- a/src/server/positions/mod.rs
+++ b/src/server/positions/mod.rs
@@ -346,7 +346,7 @@ async fn positions(
         timestamp: data.timestamp,
     };
 
-    Ok(response::Json(json!(data)))
+    Ok(response::Json(json!(data)).into())
 }
 
 pub async fn vehnt_position(
@@ -390,7 +390,7 @@ pub async fn position(
             Dao::Mobile => &memory.vemobile_positions,
         };
         if let Some(position) = memory.get(&pubkey) {
-            Ok(response::Json(json!(position)))
+            Ok(response::Json(json!(position)).into())
         } else {
             Err((
                 StatusCode::NOT_FOUND,


### PR DESCRIPTION
When the client submits a pubkey that may be parsed as a Helium pubkey, we attempt to convert it back to a Solana address (which works for ed25519 pubkeys). If  it works, we send them the redirect.